### PR TITLE
Fix typo in putDateValue method name

### DIFF
--- a/scim-sdk/src/main/java/com/unboundid/scim/sdk/ComplexValue.java
+++ b/scim-sdk/src/main/java/com/unboundid/scim/sdk/ComplexValue.java
@@ -117,7 +117,18 @@ public class ComplexValue
    * @param name sub-attribute name.
    * @param value sub-attribute value.
    */
+  @Deprecated
   public void puDateValue(final String name, final Date value) {
+    put(name, new SimpleValue(value));
+  }
+
+  /**
+   * Set the value of a Date-valued sub-attribute.  This method can be used
+   * for attributes of the SCIM type 'DateTime'.
+   * @param name sub-attribute name.
+   * @param value sub-attribute value.
+   */
+  public void putDateValue(final String name, final Date value) {
     put(name, new SimpleValue(value));
   }
 


### PR DESCRIPTION
DS-12390.   For backward compatibility, the old misspelled version is left as is
but now marked Deprecated.