### PR TITLE
Updated assemblies POM for scim-ldap

### DIFF
--- a/scim-ldap/src/main/assemblies/pom.xml
+++ b/scim-ldap/src/main/assemblies/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>com.unboundid</groupId>
             <artifactId>unboundid-ldapsdk</artifactId>
-            <version>${ldapsdk.version}</version>
+            <version>6.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.unboundid.product.scim</groupId>


### PR DESCRIPTION
Updated the assemblies POM file for scim-ldap to use a numeric value
instead a variable, to prevent errors when scanning scim-ldap.